### PR TITLE
Add plugin loader for Luma3DS

### DIFF
--- a/Luma3DS.json
+++ b/Luma3DS.json
@@ -47,7 +47,7 @@
 	"Luma3DS Plugin Loader (FIRM)": [
 		{
 			"type": "downloadRelease",
-			"repo": "mariohackandwright/Luma3DS",
+			"repo": "mariohackandglitch/Luma3DS",
 			"file": "boot.firm",
 			"output": "/boot.firm",
 			"message": "Downloading the plugin loader Luma3DS FIRM..."

--- a/Luma3DS.json
+++ b/Luma3DS.json
@@ -47,7 +47,7 @@
 	"Luma3DS Plugin Loader (FIRM)": [
 		{
 			"type": "downloadRelease",
-			"repo": "jbmagination/Luma3DS",
+			"repo": "jbmagination/Luma3DS_plg",
 			"file": "boot.firm",
 			"output": "/boot.firm",
 			"message": "Downloading the plugin loader Luma3DS FIRM..."

--- a/Luma3DS.json
+++ b/Luma3DS.json
@@ -42,6 +42,17 @@
 			"output": "/boot.firm",
 			"message": "Downloading the nightly Luma3DS FIRM..."
 		}
-	]
+		
+	],
+	"Luma3DS Plugin Loader (FIRM)": [
+		{
+			"type": "downloadRelease",
+			"repo": "mariohackandwright/Luma3DS",
+			"file": "boot.firm",
+			"output": "/boot.firm",
+			"message": "Downloading the plugin loader Luma3DS FIRM..."
+		}
+		
+	],
 }
  

--- a/Luma3DS.json
+++ b/Luma3DS.json
@@ -47,7 +47,7 @@
 	"Luma3DS Plugin Loader (FIRM)": [
 		{
 			"type": "downloadRelease",
-			"repo": "mariohackandglitch/Luma3DS",
+			"repo": "jbmagination/Luma3DS",
 			"file": "boot.firm",
 			"output": "/boot.firm",
 			"message": "Downloading the plugin loader Luma3DS FIRM..."


### PR DESCRIPTION
Originally was mariohackandglitch/Luma3DS, but decided to switch it to my fork to add the “Credits” menu item that was accidentally removed when adding the plugin loader. Will most likely send another PR with his repo if it gets fixed.